### PR TITLE
Add an option to force usage of TLS 1.2

### DIFF
--- a/ChocolateyTools/ChocolateyInstallPackage/installpackage.ps1
+++ b/ChocolateyTools/ChocolateyInstallPackage/installpackage.ps1
@@ -2,6 +2,7 @@ param (
 	[string]$packageId,
 	[string]$packageVersion,
 	[string]$alternateSource,
+	[bool]$forceTls12,
 	[string]$extraOptions
 )
 
@@ -24,6 +25,11 @@ if (-not $packageId) {
 
 $chocoVersion = & $choco --version
 Write-Output "Running Chocolatey version $chocoVersion"
+
+if($forceTls12) {
+	Write-Output "Forcing TLS 1.2"
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 
+}
 
 $chocoArgs = @()
 if([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse("0.9.8.33")) {

--- a/ChocolateyTools/ChocolateyInstallPackage/task.json
+++ b/ChocolateyTools/ChocolateyInstallPackage/task.json
@@ -20,36 +20,49 @@
         "isExpanded": false
     }],
     "instanceNameFormat": "Install $(packageId)",
-    "inputs": [{
-        "name": "packageId",
-        "type": "string",
-        "label": "Package",
-        "defaultValue": "",
-        "required": true,
-        "helpMarkDown": "The package ID of the package to install. Check https://chocolatey.org/ for available packages"
-    }, {
-        "name": "packageVersion",
-        "type": "string",
-        "label": "Version",
-        "defaultValue": "",
-        "required": false,
-        "helpMarkDown": "Specific version of the package to install. Leave empty if you want to install the latest stable version."
-    }, {
-        "name": "alternateSource",
-        "type": "string",
-        "label": "Alternate package source",
-        "defaultValue": "",
-        "required": false,
-        "groupname": "advanced",
-        "helpMarkDown": "The source to find the package(s) to install. Special sources include: ruby, webpi, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (-e.g. 'source1;source2'). Defaults to default feeds."
-    }, {
-        "name": "extraOptions",
-        "type": "string",
-        "label": "Other options",
-        "defaultValue": "",
-        "required": false,
-        "groupname": "advanced",
-        "helpMarkDown": "Add extra options or switches as needed."
+  "inputs": [
+    {
+      "name": "packageId",
+      "type": "string",
+      "label": "Package",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The package ID of the package to install. Check https://chocolatey.org/ for available packages"
+    },
+    {
+      "name": "packageVersion",
+      "type": "string",
+      "label": "Version",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specific version of the package to install. Leave empty if you want to install the latest stable version."
+    },
+    {
+      "name": "alternateSource",
+      "type": "string",
+      "label": "Alternate package source",
+      "defaultValue": "",
+      "required": false,
+      "groupname": "advanced",
+      "helpMarkDown": "The source to find the package(s) to install. Special sources include: ruby, webpi, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (-e.g. 'source1;source2'). Defaults to default feeds."
+    },
+    {
+      "name": "forceTls12",
+      "type": "boolean",
+      "label": "Force TLS 1.2",
+      "defaultValue": false,
+      "required": false,
+      "groupname": "advanced",
+      "helpMarkDown": "Sets [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ."
+    },
+    {
+      "name": "extraOptions",
+      "type": "string",
+      "label": "Other options",
+      "defaultValue": "",
+      "required": false,
+      "groupname": "advanced",
+      "helpMarkDown": "Add extra options or switches as needed."
     }],
     "execution": {
         "PowerShell": {


### PR DESCRIPTION
Without it some packages could not load files from TLS 1.2 servers (at least on Azure DevOps Runners).

I've never worked with VSTS extensions, so please double check that I didn't break anything.

Log without the TLS 1.2 option:
```powershell
##[section]Starting: Install keepass
==============================================================================
Task         : Chocolatey - Install Package
Description  : Installs a package using Chocolatey
Version      : 1.1.1
Author       : Jungerius IT
Help         : 
==============================================================================
Preparing task execution handler.
Executing the powershell script: d:\a\_tasks\ChocoInstallPackage_5a0c2b6f-5503-4ec8-9d79-8d78f31eb1fb\1.1.1\installpackage.ps1
Running Chocolatey version 0.10.13
Adding --confirm to arguments passed to Chocolatey
Installing package keepass from the Chocolatey package repository...
Chocolatey v0.10.13
Installing the following packages:
keepass
By installing you accept licenses for the packages.

Progress: Downloading keepass.install 2.42.1... 11%
Progress: Downloading keepass.install 2.42.1... 35%
Progress: Downloading keepass.install 2.42.1... 60%
Progress: Downloading keepass.install 2.42.1... 84%
Progress: Downloading keepass.install 2.42.1... 100%

Progress: Downloading keepass 2.42.1... 13%
Progress: Downloading keepass 2.42.1... 40%
Progress: Downloading keepass 2.42.1... 67%
Progress: Downloading keepass 2.42.1... 94%
Progress: Downloading keepass 2.42.1... 100%

keepass.install v2.42.1 [Approved]
keepass.install package files install completed. Performing other installation steps.
Attempt to get headers for https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.42.1/KeePass-2.42.1-Setup.exe/download failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.42.1/KeePass-2.42.1-Setup.exe/download'. Exception calling "GetResponse" with "0" argument(s): "The operation has timed out"
Downloading keepass.install 
  from 'https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.42.1/KeePass-2.42.1-Setup.exe/download'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.42.1/KeePass-2.42.1-Setup.exe/download'. Exception calling "GetResponse" with "0" argument(s): "The operation has timed out" 
This package is likely not broken for licensed users - see https://chocolatey.org/docs/features-private-cdn.
The install of keepass.install was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\keepass.install\tools\chocolateyInstall.ps1'.
 See log for details.

keepass v2.42.1 [Approved]
keepass package files install completed. Performing other installation steps.
 The install of keepass was successful.
  Software install location not explicitly set, could be in package or
  default install location if installer.

Chocolatey installed 1/2 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - keepass.install (exited 404) - Error while running 'C:\ProgramData\chocolatey\lib\keepass.install\tools\chocolateyInstall.ps1'.
 See log for details.
##[section]Finishing: Install keepass
```